### PR TITLE
自分自身が担当者/作成者の場合に名前を太字で表示する

### DIFF
--- a/sass/application.scss
+++ b/sass/application.scss
@@ -394,6 +394,11 @@ table.list {
   padding-top: 4px;
 }
 
+tr.assigned-to-me td.assigned_to,
+tr.created-by-me td.author {
+  font-weight: bold;
+}
+
 /*Quick search*/
 
 #quick-search {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -329,6 +329,11 @@ table.list thead th {
 	padding-top:4px;
 }
 
+tr.assigned-to-me td.assigned_to,
+tr.created-by-me td.author {
+	font-weight: bold;
+}
+
 /*Quick search*/
 #quick-search {	margin-top: 8px;}
 


### PR DESCRIPTION
はじめまして。gitmike theme を使用させて頂いております m(__)m

チケットの一覧ページで、自分自身が担当者/作成者の場合に名前を太字で表示するようにしてみました。
よろしければご検討ください。

※CSS については、手元の sass gem/compass gem でコンパイルするとインデントなどが変更されてしまうため、部分的に修正する形を取らせて頂きました。
