### PR TITLE
Gecko/Firefox rendering of "select" and "textarea" elements.

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -177,11 +177,7 @@ input[type="button"]:hover, input[type="submit"]:hover, input[type="reset"]:hove
 /* Fields */
 input[type="text"], input[type="password"] { padding: 2px; border: 1px solid #ddd; color: #444; font-size: .9em; }
 
-textarea, select { padding: 2px; border: 1px solid #ddd; color: #444; font-size: .9em; }
-
-input[type="text"]:focus, input[type="password"]:focus { border: 1px solid #888866; }
-
-textarea:focus, select:focus { border: 1px solid #888866; }
+textarea, select { padding: 2px; color: #444; font-size: .9em; }
 
 option { border-bottom: 1px dotted #ddd; }
 


### PR DESCRIPTION
Hi, I've just installed your theme and I like it very much. On Firefox, I've noticed one minor "ugly" part that doesn't blend in with the rest of the theme (nor the look of GitHub), that's the `select` elements - they just show up as "old-style" boxed lists (no rounded corners, no gradients etc.).

If you just remove the corresponding `border` parts like in this commit, the selection lists get rendered via Gecko's defaults and blend in nicely with the rest. The same goes for the textareas of course, as they're sharing the CSS code.

Tested with FF 20 and Chromium 25 (on the latter it looks slightly different than before, but still good).

Please feel free to reject this pull request if you don't like it (or have a better solution, as I'm definitely not a CSS guy), this was just the easiest way to point you to my commit...

Cheers
Niko
