### PR TITLE
Remove top 15px margins for ul, ol and dl in wikis

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -216,7 +216,7 @@ img.gravatar { box-shadow: 0 3px 5px rgba(0, 0, 0, 0.05); }
 .controller-wiki div#content > div.wiki { padding: 0 8px 8px 8px; }
 
 div.wiki { line-height: 1.7; }
-div.wiki p, div.wiki blockquote, div.wiki ul, div.wiki ol, div.wiki dl, div.wiki table, div.wiki pre { margin: 15px 0; }
+div.wiki p, div.wiki blockquote, div.wiki table, div.wiki pre { margin: 15px 0; }
 div.wiki ul, div.wiki ol { padding-left: 30px; }
 div.wiki h1 { font-size: 28px; }
 div.wiki h2 { font-size: 20px; }


### PR DESCRIPTION
Hi,
I suggest to remove the 15px margin on top of lists in wikis because it gives an awkward look to nested lists:
![2016-09-09-121516_158x274_scrot](https://cloud.githubusercontent.com/assets/16179121/18383747/234d5fa4-7687-11e6-8eb4-2e8be4f0aeeb.png)

In particular, it messes up the look of the {{child_pages}} macro results:
![2016-09-09-122426_437x399_scrot](https://cloud.githubusercontent.com/assets/16179121/18383984/6520b934-7688-11e6-9d11-e9dfa2064d83.png)


Result when margin removed:
![2016-09-09-122127_149x272_scrot](https://cloud.githubusercontent.com/assets/16179121/18383906/f66b171e-7687-11e6-9132-77cffb2a8628.png)
