### PR TITLE
Change License written in the README to GPLv2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ gulp debug
 
 ## License
 
-GPL3
+GNU General Public License (GPL) Version 2
 
 ## Change Log
 


### PR DESCRIPTION
This change is to make the License consistent between README, package.json, and A1 theme's License.
Because A1 theme is distributed under GPLv2, and GPLv2 and v3 are not compatible, this theme should be licensed under GPLv2.